### PR TITLE
Fix getsockopt syscall on s390x

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: snapcore/action-build@v1
 
       - name: Upload Aproxy Snap
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: snap
           path: aproxy*.snap

--- a/aproxy.go
+++ b/aproxy.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"golang.org/x/crypto/cryptobyte"
 	"io"
 	"log"
 	"log/slog"
@@ -18,9 +19,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
-
-	"golang.org/x/crypto/cryptobyte"
 )
 
 var version = "0.2.2"
@@ -268,11 +266,7 @@ func GetOriginalDst(conn *net.TCPConn) (*net.TCPAddr, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert connection to file: %w", err)
 	}
-	return GetsockoptIPv4OriginalDst(
-		int(file.Fd()),
-		syscall.SOL_IP,
-		80, // SO_ORIGINAL_DST
-	)
+	return GetsockoptIPv4OriginalDst(file.Fd())
 }
 
 // RelayTCP relays data between the incoming TCP connection and the proxy connection.

--- a/aproxy.go
+++ b/aproxy.go
@@ -21,7 +21,7 @@ import (
 	"sync/atomic"
 )
 
-var version = "0.2.2"
+var version = "0.2.3"
 
 // PrereadConn is a wrapper around net.Conn that supports pre-reading from the underlying connection.
 // Any Read before the EndPreread can be undone and read again by calling the EndPreread function.

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module aproxy
 
 go 1.21
 
-require golang.org/x/crypto v0.31.0
+require golang.org/x/crypto v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
-golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
+golang.org/x/crypto v0.33.0 h1:IOBPskki6Lysi0lo9qQvbxiQ+FvsCC/YWOecCHAixus=
+golang.org/x/crypto v0.33.0/go.mod h1:bVdXmD7IV/4GdElGPozy6U7lWdRXA4qyRVGJV57uQ5M=

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: aproxy
-version: 0.2.2
+version: 0.2.3
 summary: Transparent proxy for HTTP and HTTPS/TLS connections.
 description: |
   Aproxy is a transparent proxy for HTTP and HTTPS/TLS connections. By 

--- a/syscall_linux.go
+++ b/syscall_linux.go
@@ -10,14 +10,14 @@ import (
 	"unsafe"
 )
 
-func GetsockoptIPv4OriginalDst(fd, level, opt int) (*net.TCPAddr, error) {
+func GetsockoptIPv4OriginalDst(fd uintptr) (*net.TCPAddr, error) {
 	var sockaddr [16]byte
-	size := 16
+	var size uint32 = 16
 	_, _, e := syscall.Syscall6(
 		syscall.SYS_GETSOCKOPT,
-		uintptr(fd),
-		uintptr(level),
-		uintptr(opt),
+		fd,
+		uintptr(syscall.SOL_IP),
+		uintptr(80), // SO_ORIGINAL_DST
 		uintptr(unsafe.Pointer(&sockaddr)),
 		uintptr(unsafe.Pointer(&size)),
 		0,


### PR DESCRIPTION
The `GetsockoptIPv4OriginalDst` function uses a pointer to `int` as an argument for the `getsockopt` syscall. On 64-bit systems, the `int` type will be 64-bit, but `getsockopt` requires a pointer to a 32-bit integer.

On little-endian architectures (amd64, arm64, etc.), a pointer to a 64-bit integer is the same as a pointer to a 32-bit integer if the integer is small enough. On big-endian architectures (e.g., s390x), this is different.

Update the `GetsockoptIPv4OriginalDst` function to use the correct type for the size argument and apply some small refactoring to this function.