### PR TITLE
chore: bump package version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module aproxy
 
 go 1.21
 
-require golang.org/x/crypto v0.31.0
+require golang.org/x/crypto v0.32.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
 golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
+golang.org/x/crypto v0.32.0 h1:euUpcYgM8WcP71gNpTqQCn6rC2t6ULUPiOzfWaXVVfc=
+golang.org/x/crypto v0.32.0/go.mod h1:ZnnJkOaASj8g0AjIduWNlq2NRxL0PlBrbKVyZ6V/Ugc=


### PR DESCRIPTION
Bump package version to allow using already existing sourcecraft package go-golang-x-crypto