### PR TITLE
Fix HTTP protocol version replacement in HTTP/1.0 requests

### DIFF
--- a/aproxy.go
+++ b/aproxy.go
@@ -315,7 +315,9 @@ func RelayHTTP(conn io.ReadWriter, proxyConn io.ReadWriteCloser, logger *slog.Lo
 			return
 		}
 		reqStr := buf.String()
-		reqStr = strings.Replace(reqStr, "HTTP/1.1", "HTTP/1.0", 1)
+		crlfIndex := strings.Index(reqStr, "\r\n")
+		protoSpaceIndex := strings.LastIndex(reqStr[:crlfIndex], " ")
+		reqStr = reqStr[:protoSpaceIndex+1] + "HTTP/1.0" + reqStr[crlfIndex:]
 		_, err = proxyConn.Write([]byte(reqStr))
 		if err != nil {
 			logger.Error("failed to send HTTP request to proxy", "error", err)


### PR DESCRIPTION
In the current implementation, the HTTP protocol version replacement is applied when the original request is `HTTP/1.0`. However, it only replaces the first occurrence of the HTTP protocol version string. This means that in rare cases where the HTTP request path contains a protocol version string, for example, `http://example.com/HTTP/1.1`, the version inside the path may be replaced instead of the actual HTTP protocol version.

This pull request uses a more accurate replacement method to address the issue.