### PR TITLE
Add generic TCP4 support

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -43,12 +43,12 @@ jobs:
           table ip aproxy {
                   chain prerouting {
                           type nat hook prerouting priority dstnat; policy accept;
-                          ip daddr != \$private-ips tcp dport { 80, 443, 11371, 23 } counter dnat to \$default-ip:\$aproxy-port
+                          ip daddr != \$private-ips tcp dport { 80, 443, 11371, 4242 } counter dnat to \$default-ip:\$aproxy-port
                   }
 
                   chain output {
                           type nat hook output priority -100; policy accept;
-                          ip daddr != \$private-ips tcp dport { 80, 443, 11371, 23 } counter dnat to \$default-ip:\$aproxy-port
+                          ip daddr != \$private-ips tcp dport { 80, 443, 11371, 4242 } counter dnat to \$default-ip:\$aproxy-port
                   }
           }
           EOF
@@ -70,16 +70,17 @@ jobs:
         run: |
           timeout 60 gpg -vvv --keyserver hkp://keyserver.ubuntu.com --recv-keys E1DE584A8CCA52DC29550F18ABAC58F075A17EFA
 
-      - name: Test TCP4 (using telnet)
+      - name: Test TCP4
         run: |
-          timeout 60 curl --noproxy "*" telnet://example.com <<< "foobar"
+          sudo apt install -y socat
+          timeout 60 socat /dev/null TCP4:tcpbin.com:4242
 
       - name: Test Access Logs
         run: |
           sudo snap logs aproxy.aproxy | grep -Fq "example.com:80"
           sudo snap logs aproxy.aproxy | grep -Fq "example.com:443"
           sudo snap logs aproxy.aproxy | grep -Fq "keyserver.ubuntu.com:11371"
-          sudo snap logs aproxy.aproxy | grep -Eq "TCP4:[0-9.]+:23"
+          sudo snap logs aproxy.aproxy | grep -Eq "TCP4:[0-9.]+:4242"
 
       - name: Show Access Logs
         if: failure()

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -80,7 +80,7 @@ jobs:
           sudo snap logs aproxy.aproxy | grep -Fq "example.com:80"
           sudo snap logs aproxy.aproxy | grep -Fq "example.com:443"
           sudo snap logs aproxy.aproxy | grep -Fq "keyserver.ubuntu.com:11371"
-          sudo snap logs aproxy.aproxy | grep -Eq "TCP4:[0-9.]+:4242"
+          sudo snap logs aproxy.aproxy | grep -Eq "[0-9.]+:4242"
 
       - name: Show Access Logs
         if: failure()

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -27,11 +27,11 @@ jobs:
       - name: Install aproxy Snap
         run: |
           sudo snap install --dangerous aproxy_*_amd64.snap
-      
+
       - name: Show aproxy Configuration
         run: |
           sudo snap get aproxy
-      
+
       - name: Configure aproxy
         run: |
           sudo nft -f - << EOF

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -66,20 +66,20 @@ jobs:
         run: |
           timeout 60 curl --noproxy "*" https://example.com -svS -o /dev/null
 
-      - name: Start tcpdump in background
-        run: |
-          sudo tcpdump -i any -s 65535 -w capture.pcap &
-          echo $! > tcpdump.pid
-
       - name: Test HKP
         run: |
           timeout 60 gpg -vvv --keyserver hkp://keyserver.ubuntu.com --recv-keys E1DE584A8CCA52DC29550F18ABAC58F075A17EFA
+
+      - name: Test TCP4 (using telnet)
+        run: |
+          timeout 60 curl --noproxy "*" telnet://example.com <<< "foobar"
 
       - name: Test Access Logs
         run: |
           sudo snap logs aproxy.aproxy | grep -Fq "example.com:80"
           sudo snap logs aproxy.aproxy | grep -Fq "example.com:443"
           sudo snap logs aproxy.aproxy | grep -Fq "keyserver.ubuntu.com:11371"
+          sudo snap logs aproxy.aproxy | grep -Eq "TCP4:[0-9.]+:23"
 
       - name: Show Access Logs
         if: failure()

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -43,12 +43,12 @@ jobs:
           table ip aproxy {
                   chain prerouting {
                           type nat hook prerouting priority dstnat; policy accept;
-                          ip daddr != \$private-ips tcp dport { 80, 443, 11371 } counter dnat to \$default-ip:\$aproxy-port
+                          ip daddr != \$private-ips tcp dport { 80, 443, 11371, 23 } counter dnat to \$default-ip:\$aproxy-port
                   }
 
                   chain output {
                           type nat hook output priority -100; policy accept;
-                          ip daddr != \$private-ips tcp dport { 80, 443, 11371 } counter dnat to \$default-ip:\$aproxy-port
+                          ip daddr != \$private-ips tcp dport { 80, 443, 11371, 23 } counter dnat to \$default-ip:\$aproxy-port
                   }
           }
           EOF

--- a/aproxy.go
+++ b/aproxy.go
@@ -383,7 +383,7 @@ func HandleConn(conn net.Conn, proxy string) {
 		logger.Info("relay HTTP connection to proxy")
 		RelayHTTP(consigned, proxyConn, logger)
 	default:
-		logger = logger.With("host", "TCP4:" + dst.IP.String() + ":" + strconv.Itoa(dst.Port))
+		logger = logger.With("host", "TCP4:"+dst.IP.String()+":"+strconv.Itoa(dst.Port))
 		proxyConn, err := DialProxy(proxy)
 		if err != nil {
 			logger.Error("failed to connect to tcp proxy", "error", err)

--- a/aproxy.go
+++ b/aproxy.go
@@ -16,7 +16,6 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -24,7 +23,7 @@ import (
 	"golang.org/x/crypto/cryptobyte"
 )
 
-var version = "0.2.3"
+var version = "0.2.4"
 
 // PrereadConn is a wrapper around net.Conn that supports pre-reading from the underlying connection.
 // Any Read before the EndPreread can be undone and read again by calling the EndPreread function.
@@ -383,8 +382,8 @@ func HandleConn(conn net.Conn, proxy string) {
 		logger.Info("relay HTTP connection to proxy")
 		RelayHTTP(consigned, proxyConn, logger)
 	default:
-		logger = logger.With("host", "TCP4:"+dst.IP.String()+":"+strconv.Itoa(dst.Port))
-		proxyConn, err := DialProxy(proxy)
+		logger = logger.With("host", fmt.Sprintf("%s:%d", dst.IP.String(), dst.Port))
+		proxyConn, err := DialProxyConnect(proxy, dst.IP.String())
 		if err != nil {
 			logger.Error("failed to connect to tcp proxy", "error", err)
 			return

--- a/aproxy.go
+++ b/aproxy.go
@@ -221,6 +221,7 @@ func DialProxy(proxy string) (net.Conn, error) {
 }
 
 // DialProxyConnect dials the TCP connection and finishes the HTTP CONNECT handshake with the proxy.
+// dst: HOST:PORT or IP:PORT
 func DialProxyConnect(proxy string, dst string) (net.Conn, error) {
 	conn, err := DialProxy(proxy)
 	if err != nil {
@@ -383,7 +384,7 @@ func HandleConn(conn net.Conn, proxy string) {
 		RelayHTTP(consigned, proxyConn, logger)
 	default:
 		logger = logger.With("host", fmt.Sprintf("%s:%d", dst.IP.String(), dst.Port))
-		proxyConn, err := DialProxyConnect(proxy, dst.IP.String())
+		proxyConn, err := DialProxyConnect(proxy, fmt.Sprintf("%s:%d", dst.IP.String(), dst.Port))
 		if err != nil {
 			logger.Error("failed to connect to tcp proxy", "error", err)
 			return


### PR DESCRIPTION
Generic TCP4 is provided as a fallback mechanism when the port is not one of the already supported protocols (HTTP, HTTPS, HKP).