### PR TITLE
End PrereadConn before starting TCP relay

### DIFF
--- a/aproxy.go
+++ b/aproxy.go
@@ -385,6 +385,7 @@ func HandleConn(conn net.Conn, proxy string) {
 		logger.Info("relay HTTP connection to proxy")
 		RelayHTTP(consigned, proxyConn, logger)
 	default:
+		consigned.EndPreread()
 		logger = logger.With("host", fmt.Sprintf("%s:%d", dst.IP.String(), dst.Port))
 		proxyConn, err := DialProxyConnect(proxy, fmt.Sprintf("%s:%d", dst.IP.String(), dst.Port))
 		if err != nil {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: aproxy
-version: 0.2.4
+version: 0.2.5
 summary: Transparent proxy for HTTP and HTTPS/TLS connections.
 description: |
   Aproxy is a transparent proxy for HTTP and HTTPS/TLS connections. By 


### PR DESCRIPTION
In the current implementation, PrereadConn isn’t terminated before starting the TCP relay. As a result, aproxy buffers the entire TCP stream in memory, which can trigger OOM kills on large or long-lived connections.

Call consigned.EndPreread() at the start of the TCP relay to release the preread buffer and prevent unbounded growth.