### PR TITLE
Update go module to use canonical name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,12 @@
 name: Release
 
 on:
-  push:
-    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., v1.0.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -23,11 +27,7 @@ jobs:
       - name: Create tag
         id: tag
         run: |
-          LAST_TAG=$(git describe --tags --match "v[0-9]*.[0-9]*.[0-9]*" --abbrev=0 2>/dev/null || echo "v0.0.0")
-          VERSION=${LAST_TAG#v}
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
-          PATCH=$((PATCH + 1))
-          TAG="v${MAJOR}.${MINOR}.${PATCH}"
+          TAG="${{ inputs.tag }}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module aproxy
+module github.com/canonical/aproxy
 
 go 1.24.0
 


### PR DESCRIPTION
- Address the [issue](https://github.com/canonical/sd-tools/issues/3469) raised by sd-tools.
- Update the release.yaml for user input on tag since it currently updates patch version but this change requires a major version bump.